### PR TITLE
Unify section backgrounds for smooth transitions

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -1005,163 +1005,55 @@ footer {
         background: linear-gradient(135deg, #1a2344 0%, #162238 20%, #0f1a2e 40%, #0b1020 60%, #0d1424 80%, #11182d 100%);
     }
 
-    /* Hero section - subtle gradient background */
+    /* Hero section */
     .hero {
-        background: linear-gradient(135deg, rgba(26, 35, 68, 0.3) 0%, rgba(11, 16, 32, 0.1) 100%);
         position: relative;
         margin: 0;
+        background: transparent;
     }
 
-    .hero::before {
-        content: '';
-        position: absolute;
-        top: 0;
-        left: 0;
-        right: 0;
-        bottom: 0;
-        background: radial-gradient(600px 400px at 50% 0%, rgba(233, 109, 70, 0.08) 0%, transparent 70%);
-        pointer-events: none;
-        z-index: -1;
-    }
 
-    /* Services section - card-like background */
+    /* Services section */
     #services {
-        background: linear-gradient(180deg, rgba(17, 24, 45, 0.4) 0%, rgba(11, 16, 32, 0.2) 100%);
         position: relative;
         margin: 0;
+        background: transparent;
     }
 
-    #services::before {
-        content: '';
-        position: absolute;
-        top: 0;
-        left: 0;
-        right: 0;
-        bottom: 0;
-        background: radial-gradient(800px 300px at 20% 80%, rgba(255, 255, 255, 0.02) 0%, transparent 70%);
-        pointer-events: none;
-        z-index: -1;
-    }
 
-    /* Trusted by section - subtle accent background */
+    /* Trusted by section */
     #clients {
-        background: linear-gradient(135deg, rgba(233, 109, 70, 0.05) 0%, rgba(11, 16, 32, 0.1) 100%);
         position: relative;
         margin: 0;
+        background: transparent;
     }
 
-    #clients::before {
-        content: '';
-        position: absolute;
-        top: 0;
-        left: 0;
-        right: 0;
-        bottom: 0;
-        background: radial-gradient(600px 400px at 80% 50%, rgba(233, 109, 70, 0.03) 0%, transparent 70%);
-        pointer-events: none;
-        z-index: -1;
-    }
 
-    /* Process section - structured background */
+    /* Process section */
     #process {
-        background: linear-gradient(180deg, rgba(17, 24, 45, 0.3) 0%, rgba(11, 16, 32, 0.1) 100%);
         position: relative;
         margin: 0;
+        background: transparent;
     }
 
-    #process::before {
-        content: '';
-        position: absolute;
-        top: 0;
-        left: 0;
-        right: 0;
-        bottom: 0;
-        background:
-            radial-gradient(400px 200px at 20% 30%, rgba(255, 255, 255, 0.02) 0%, transparent 60%),
-            radial-gradient(400px 200px at 80% 70%, rgba(233, 109, 70, 0.02) 0%, transparent 60%);
-        pointer-events: none;
-        z-index: -1;
-    }
 
-    /* Contact section - prominent background */
+    /* Contact section */
     #contact {
-        background: linear-gradient(135deg, rgba(17, 24, 45, 0.5) 0%, rgba(11, 16, 32, 0.3) 100%);
         position: relative;
         margin: 0;
+        background: transparent;
     }
 
-    #contact::before {
-        content: '';
-        position: absolute;
-        top: 0;
-        left: 0;
-        right: 0;
-        bottom: 0;
-        background:
-            radial-gradient(700px 400px at 20% 30%, rgba(233, 109, 70, 0.06) 0%, transparent 70%),
-            radial-gradient(500px 300px at 80% 70%, rgba(255, 255, 255, 0.03) 0%, transparent 70%);
-        pointer-events: none;
-        z-index: -1;
-    }
-
-    /* Ensure content is above background layers */
-    .hero .container,
-    #services .container,
-    #clients .container,
-    #process .container,
-    #contact .container {
-        position: relative;
-        z-index: 1;
-    }
 }
 
 /* Enhanced mobile backgrounds for smaller screens */
 @media (max-width: 480px) {
-    .hero {
-        background: linear-gradient(135deg, rgba(26, 35, 68, 0.4) 0%, rgba(11, 16, 32, 0.15) 100%);
-    }
-
-    #services {
-        background: linear-gradient(180deg, rgba(17, 24, 45, 0.5) 0%, rgba(11, 16, 32, 0.25) 100%);
-    }
-
-    #clients {
-        background: linear-gradient(135deg, rgba(233, 109, 70, 0.08) 0%, rgba(11, 16, 32, 0.15) 100%);
-    }
-
-    #process {
-        background: linear-gradient(135deg, rgba(17, 24, 45, 0.4) 0%, rgba(11, 16, 32, 0.2) 100%);
-    }
-
+    .hero,
+    #services,
+    #clients,
+    #process,
     #contact {
-        background: linear-gradient(135deg, rgba(17, 24, 45, 0.6) 0%, rgba(11, 16, 32, 0.4) 100%);
-    }
-}
-
-/* Landscape mobile optimization for backgrounds */
-@media (max-width: 768px) and (orientation: landscape) {
-    .hero::before {
-        background: radial-gradient(800px 300px at 50% 0%, rgba(233, 109, 70, 0.06) 0%, transparent 70%);
-    }
-
-    #services::before {
-        background: radial-gradient(1000px 200px at 20% 50%, rgba(255, 255, 255, 0.015) 0%, transparent 70%);
-    }
-
-    #clients::before {
-        background: radial-gradient(800px 200px at 80% 50%, rgba(233, 109, 70, 0.025) 0%, transparent 70%);
-    }
-
-    #process::before {
-        background:
-            radial-gradient(600px 150px at 30% 20%, rgba(255, 255, 255, 0.015) 0%, transparent 60%),
-            radial-gradient(600px 150px at 70% 80%, rgba(233, 109, 70, 0.015) 0%, transparent 60%);
-    }
-
-    #contact::before {
-        background:
-            radial-gradient(900px 250px at 20% 30%, rgba(233, 109, 70, 0.04) 0%, transparent 70%),
-            radial-gradient(700px 200px at 80% 70%, rgba(255, 255, 255, 0.02) 0%, transparent 70%);
+        background: transparent;
     }
 }
 


### PR DESCRIPTION
## Summary
- Remove per-section overlay gradients so mobile backgrounds stay consistent
- Keep services, clients, process, and contact sections transparent for seamless transitions

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b3d82857b0832dba2ad2a8883b5b79